### PR TITLE
Upload refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,11 @@ script:
 after_success:
   - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
   - if [ "$TRAVIS_BRANCH" == "master" ]; then
-    echo "build for master branch";
+    echo "build for master branch $TRAVIS_BRANCH";
     docker tag nestal/hearty_rabbit nestal/hearty_rabbit:$TRAVIS_BUILD_NUMBER;
     fi;
-  - docker tag nestal/hearty_rabbit nestal/hearty_rabbit:$TRAVIS_BRANCH
+  - if [ "$TRAVIS_BRANCH" == "develop" ] || [ "$TRAVIS_BRANCH" == "master" ]; then
+    docker tag nestal/hearty_rabbit nestal/hearty_rabbit:$TRAVIS_BRANCH
+    fi;
   - docker push nestal/hearty_rabbit
   - echo "Pushed docker image to hub"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ script:
 
 after_success:
   - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
-  - if [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "release_v0.1" ]; then
+  - if [ "$TRAVIS_BRANCH" == "master" ]; then
+    echo "build for master branch";
     docker tag nestal/hearty_rabbit nestal/hearty_rabbit:$TRAVIS_BUILD_NUMBER;
     fi;
   - docker tag nestal/hearty_rabbit nestal/hearty_rabbit:$TRAVIS_BRANCH

--- a/src/hrb/BlobDatabase.cc
+++ b/src/hrb/BlobDatabase.cc
@@ -73,13 +73,13 @@ BlobDatabase::BlobResponse BlobDatabase::response(
 	auto path = dest(id);
 
 	std::error_code ec;
-	BlobFile blob_obj{path, id, rendition, m_cfg.renditions(), ec};
+	BlobFile blob_obj{path, id};
 
 	if (ec)
 		return BlobResponse{http::status::not_found, version};
 
 	// Advice the kernel that we only read the memory in one pass
-	auto mmap{std::move(blob_obj.mmap())};
+	auto mmap = blob_obj.rendition(rendition, m_cfg.renditions(), ec);
 	mmap.cache();
 
 	BlobResponse res{

--- a/src/hrb/BlobDatabase.cc
+++ b/src/hrb/BlobDatabase.cc
@@ -43,11 +43,7 @@ void BlobDatabase::prepare_upload(UploadFile& result, std::error_code& ec) const
 
 BlobFile BlobDatabase::save(UploadFile&& tmp, std::string_view filename, std::error_code& ec)
 {
-	auto blob_obj = BlobFile::upload(std::move(tmp), m_magic, m_cfg.renditions(), filename, ec);
-	if (!ec)
-		blob_obj.save(dest(blob_obj.ID()), ec);
-
-	return blob_obj;
+	return BlobFile::upload(std::move(tmp), dest(tmp.ID()), m_magic, m_cfg.renditions(), filename, ec);
 }
 
 fs::path BlobDatabase::dest(const ObjectID& id, std::string_view) const

--- a/src/hrb/BlobDatabase.cc
+++ b/src/hrb/BlobDatabase.cc
@@ -41,9 +41,9 @@ void BlobDatabase::prepare_upload(UploadFile& result, std::error_code& ec) const
 		ec.assign(err.value(), err.category());
 }
 
-BlobFile BlobDatabase::save(UploadFile&& tmp, std::string_view filename, std::error_code& ec)
+BlobFile BlobDatabase::save(UploadFile&& tmp, std::error_code& ec)
 {
-	return BlobFile::upload(std::move(tmp), dest(tmp.ID()), m_magic, m_cfg.renditions(), filename, ec);
+	return BlobFile::upload(std::move(tmp), dest(tmp.ID()), m_magic, ec);
 }
 
 fs::path BlobDatabase::dest(const ObjectID& id, std::string_view) const

--- a/src/hrb/BlobDatabase.hh
+++ b/src/hrb/BlobDatabase.hh
@@ -30,6 +30,7 @@ class MMapResponseBody;
 class Magic;
 class UploadFile;
 
+/// \brief  On-disk database that stores the blobs in files and directories
 class BlobDatabase
 {
 public:

--- a/src/hrb/BlobDatabase.hh
+++ b/src/hrb/BlobDatabase.hh
@@ -40,7 +40,7 @@ public:
 	explicit BlobDatabase(const Configuration& cfg);
 
 	void prepare_upload(UploadFile& result, std::error_code& ec) const;
-	BlobFile save(UploadFile&& tmp, std::string_view filename, std::error_code& ec);
+	BlobFile save(UploadFile&& tmp, std::error_code& ec);
 
 	fs::path dest(const ObjectID& id, std::string_view rendition = {}) const;
 

--- a/src/hrb/BlobFile.cc
+++ b/src/hrb/BlobFile.cc
@@ -135,8 +135,10 @@ MMap BlobFile::rendition(std::string_view rendition, const RenditionSetting& cfg
 	if (!cfg.valid(rendition) && rendition != hrb::master_rendition)
 		rendition = cfg.default_rendition();
 
+	auto rend_path = m_dir/std::string{rendition};
+
 	// generate the rendition if it doesn't exist
-	if (rendition != hrb::master_rendition && !exists(m_dir/std::string{rendition}))
+	if (rendition != hrb::master_rendition && !exists(rend_path))
 	{
 		auto master = MMap::open(m_dir/hrb::master_rendition, ec);
 		if (!ec)
@@ -148,12 +150,11 @@ MMap BlobFile::rendition(std::string_view rendition, const RenditionSetting& cfg
 				ec
 			);
 			if (!tb.empty())
-				save_blob(tb, m_dir / std::string{rendition}, ec);
+				save_blob(tb, rend_path, ec);
 		}
 	}
 
-	auto resized = m_dir/std::string{rendition};
-	return MMap::open(exists(resized) ? resized : m_dir/hrb::master_rendition, ec);
+	return MMap::open(exists(rend_path) ? rend_path : m_dir/hrb::master_rendition, ec);
 }
 
 CollEntry BlobFile::entry() const

--- a/src/hrb/BlobFile.cc
+++ b/src/hrb/BlobFile.cc
@@ -76,13 +76,12 @@ BlobFile BlobFile::upload(
 
 	// commit result
 	result.m_id     = tmp.ID();
-	result.m_tmp    = std::move(tmp);
 	result.m_phash  = hrb::phash(master.buffer());
 	result.m_mmap   = std::move(master);
 	result.m_coll_entry   = CollEntry::create(Permission{}, filename, mime);
 
 	if (!ec)
-		result.save(dir, ec);
+		result.save(tmp, dir, ec);
 
 	return result;
 }
@@ -115,7 +114,7 @@ void save_blob(const Blob& blob, const fs::path& dest, std::error_code& ec)
 		ec.assign(0, ec.category());
 }
 
-void BlobFile::save(const fs::path& dir, std::error_code& ec) const
+void BlobFile::save(UploadFile& tmp, const fs::path& dir, std::error_code& ec) const
 {
 	boost::system::error_code bec;
 	fs::create_directories(dir, bec);
@@ -127,7 +126,7 @@ void BlobFile::save(const fs::path& dir, std::error_code& ec) const
 
 	// Try moving the temp file to our destination first. If failed, use
 	// deep copy instead.
-	m_tmp.move(dir/hrb::master_rendition, ec);
+	tmp.move(dir/hrb::master_rendition, ec);
 
 	// Save the renditions, if any.
 	for (auto&& [name, rend] : m_rend)

--- a/src/hrb/BlobFile.cc
+++ b/src/hrb/BlobFile.cc
@@ -52,7 +52,7 @@ BlobFile BlobFile::upload(
 	if (mime == "image/jpeg")
 	{
 		// generate default rendition
-		auto rotated = generate_rendition(
+		auto rotated = generate_rendition_from_jpeg(
 			master.buffer(),
 			cfg.dimension(cfg.default_rendition()),
 			cfg.quality(cfg.default_rendition()),
@@ -155,7 +155,12 @@ BlobFile::BlobFile(
 		auto master = MMap::open(dir/hrb::master_rendition, ec);
 		if (!ec)
 		{
-			auto tb = generate_rendition(master.buffer(), cfg.dimension(rendition), cfg.quality(rendition), ec);
+			auto tb = generate_rendition_from_jpeg(
+				master.buffer(),
+				cfg.dimension(rendition),
+				cfg.quality(rendition),
+				ec
+			);
 			if (!tb.empty())
 				save_blob(tb, dir / std::string{rendition}, ec);
 		}
@@ -170,16 +175,16 @@ CollEntry BlobFile::entry() const
 	return CollEntry{m_coll_entry};
 }
 
-TurboBuffer BlobFile::generate_rendition(BufferView master, Size2D dim, int quality, std::error_code& ec)
+TurboBuffer BlobFile::generate_rendition_from_jpeg(BufferView jpeg_master, Size2D dim, int quality, std::error_code& ec)
 {
 	RotateImage transform;
-	auto rotated = transform.auto_rotate(master, ec);
+	auto rotated = transform.auto_rotate(jpeg_master, ec);
 
 	if (!ec)
 	{
 		JPEG img{
-			rotated.empty() ? master.data() : rotated.data(),
-			rotated.empty() ? master.size() : rotated.size(),
+			rotated.empty() ? jpeg_master.data() : rotated.data(),
+			rotated.empty() ? jpeg_master.size() : rotated.size(),
 			dim
 		};
 

--- a/src/hrb/BlobFile.cc
+++ b/src/hrb/BlobFile.cc
@@ -98,7 +98,7 @@ MMap BlobFile::rendition(std::string_view rendition, const RenditionSetting& cfg
 	auto rend_path = m_dir/std::string{rendition};
 
 	// generate the rendition if it doesn't exist
-	if (rendition != hrb::master_rendition && !exists(rend_path) && m_mime == "image/jpeg")
+	if (rendition != hrb::master_rendition && !exists(rend_path))
 	{
 		auto master = MMap::open(m_dir/hrb::master_rendition, ec);
 		if (!ec)

--- a/src/hrb/BlobFile.hh
+++ b/src/hrb/BlobFile.hh
@@ -36,7 +36,7 @@ class BlobFile
 {
 public:
 	BlobFile() = default;
-	BlobFile(const fs::path& dir, const ObjectID& id, std::string_view rendition, const RenditionSetting& cfg, std::error_code& ec);
+	BlobFile(const fs::path& dir, const ObjectID& id);
 
 	static BlobFile upload(
 		UploadFile&& tmp,
@@ -47,10 +47,7 @@ public:
 		std::error_code& ec
 	);
 
-	void generate_jpeg_rendition(const JPEGRenditionSetting& cfg, std::string_view rendition, const fs::path& dir, std::error_code& err);
-
-	BufferView buffer() const;
-	MMap& mmap() {return m_mmap;}
+	MMap rendition(std::string_view rendition, const RenditionSetting& cfg, std::error_code& ec) const;
 
 	const ObjectID& ID() const {return m_id;}
 	CollEntry entry() const;
@@ -58,13 +55,14 @@ public:
 	auto phash() const {return m_phash;}
 
 private:
+	void generate_jpeg_rendition(BufferView jpeg_master, const JPEGRenditionSetting& cfg, std::string_view rendition, const fs::path& dir, std::error_code& err);
 	static TurboBuffer generate_rendition_from_jpeg(BufferView jpeg_master, Size2D dim, int quality, std::error_code& ec);
 
 private:
 	ObjectID    m_id{};
+	fs::path    m_dir;
 	std::string m_coll_entry;
 	PHash       m_phash{};
-	MMap        m_mmap;
 };
 
 } // end of namespace hrb

--- a/src/hrb/BlobFile.hh
+++ b/src/hrb/BlobFile.hh
@@ -25,7 +25,6 @@
 
 namespace hrb {
 
-class CollEntry;
 class EXIF2;
 class Magic;
 class RenditionSetting;
@@ -42,15 +41,13 @@ public:
 		UploadFile&& tmp,
 		const fs::path& dir,
 		const Magic& magic,
-		const RenditionSetting& cfg,
-		std::string_view filename,
 		std::error_code& ec
 	);
 
 	MMap rendition(std::string_view rendition, const RenditionSetting& cfg, std::error_code& ec) const;
 
 	const ObjectID& ID() const {return m_id;}
-	CollEntry entry() const;
+	std::string mime() const {return m_mime;}
 
 	auto phash() const {return m_phash;}
 
@@ -60,7 +57,7 @@ private:
 private:
 	ObjectID    m_id{};
 	fs::path    m_dir;
-	std::string m_coll_entry;
+	std::string m_mime;
 	PHash       m_phash{};
 };
 

--- a/src/hrb/BlobFile.hh
+++ b/src/hrb/BlobFile.hh
@@ -36,8 +36,7 @@ class BlobFile
 public:
 	BlobFile() = default;
 	BlobFile(const fs::path& dir, const ObjectID& id);
-
-	static BlobFile upload(
+	BlobFile(
 		UploadFile&& tmp,
 		const fs::path& dir,
 		const Magic& magic,

--- a/src/hrb/BlobFile.hh
+++ b/src/hrb/BlobFile.hh
@@ -60,14 +60,13 @@ public:
 
 private:
 	static TurboBuffer generate_rendition_from_jpeg(BufferView jpeg_master, Size2D dim, int quality, std::error_code& ec);
-	void save(const fs::path& dir, std::error_code& ec) const;
+	void save(UploadFile& tmp, const fs::path& dir, std::error_code& ec) const;
 
 private:
 	ObjectID    m_id{};
 	std::string m_coll_entry;
 	PHash       m_phash{};
 
-	mutable UploadFile  m_tmp;
 	MMap                m_mmap;
 	std::unordered_map<std::string, TurboBuffer> m_rend;
 };

--- a/src/hrb/BlobFile.hh
+++ b/src/hrb/BlobFile.hh
@@ -40,6 +40,7 @@ public:
 
 	static BlobFile upload(
 		UploadFile&& tmp,
+		const fs::path& dir,
 		const Magic& magic,
 		const RenditionSetting& cfg,
 		std::string_view filename,
@@ -52,11 +53,11 @@ public:
 	const ObjectID& ID() const {return m_id;}
 	CollEntry entry() const;
 
-	void save(const fs::path& dir, std::error_code& ec) const;
 	auto phash() const {return m_phash;}
 
 private:
 	static TurboBuffer generate_rendition_from_jpeg(BufferView jpeg_master, Size2D dim, int quality, std::error_code& ec);
+	void save(const fs::path& dir, std::error_code& ec) const;
 
 private:
 	ObjectID    m_id{};

--- a/src/hrb/BlobFile.hh
+++ b/src/hrb/BlobFile.hh
@@ -30,6 +30,7 @@ class CollEntry;
 class EXIF2;
 class Magic;
 class RenditionSetting;
+class JPEGRenditionSetting;
 class UploadFile;
 
 class BlobFile
@@ -46,6 +47,8 @@ public:
 		std::string_view filename,
 		std::error_code& ec
 	);
+
+	void generate_jpeg_rendition(const JPEGRenditionSetting& cfg, std::string_view rendition);
 
 	BufferView buffer() const;
 	MMap& mmap() {return m_mmap;}

--- a/src/hrb/BlobFile.hh
+++ b/src/hrb/BlobFile.hh
@@ -43,11 +43,11 @@ public:
 		std::error_code& ec
 	);
 
+	// if the rendition does not exists but it's a valid one, it will be generated dynamically
 	MMap rendition(std::string_view rendition, const RenditionSetting& cfg, std::error_code& ec) const;
 
 	const ObjectID& ID() const {return m_id;}
 	std::string mime() const {return m_mime;}
-
 	auto phash() const {return m_phash;}
 
 private:

--- a/src/hrb/BlobFile.hh
+++ b/src/hrb/BlobFile.hh
@@ -56,7 +56,7 @@ public:
 	auto phash() const {return m_phash;}
 
 private:
-	static TurboBuffer generate_rendition(BufferView master, Size2D dim, int quality, std::error_code& ec);
+	static TurboBuffer generate_rendition_from_jpeg(BufferView jpeg_master, Size2D dim, int quality, std::error_code& ec);
 
 private:
 	ObjectID    m_id{};

--- a/src/hrb/BlobFile.hh
+++ b/src/hrb/BlobFile.hh
@@ -21,7 +21,6 @@
 #include "util/FS.hh"
 #include "util/MMap.hh"
 
-#include <unordered_map>
 #include <system_error>
 
 namespace hrb {
@@ -48,7 +47,7 @@ public:
 		std::error_code& ec
 	);
 
-	void generate_jpeg_rendition(const JPEGRenditionSetting& cfg, std::string_view rendition, std::error_code& err);
+	void generate_jpeg_rendition(const JPEGRenditionSetting& cfg, std::string_view rendition, const fs::path& dir, std::error_code& err);
 
 	BufferView buffer() const;
 	MMap& mmap() {return m_mmap;}
@@ -60,15 +59,12 @@ public:
 
 private:
 	static TurboBuffer generate_rendition_from_jpeg(BufferView jpeg_master, Size2D dim, int quality, std::error_code& ec);
-	void save(UploadFile& tmp, const fs::path& dir, std::error_code& ec) const;
 
 private:
 	ObjectID    m_id{};
 	std::string m_coll_entry;
 	PHash       m_phash{};
-
-	MMap                m_mmap;
-	std::unordered_map<std::string, TurboBuffer> m_rend;
+	MMap        m_mmap;
 };
 
 } // end of namespace hrb

--- a/src/hrb/BlobFile.hh
+++ b/src/hrb/BlobFile.hh
@@ -55,7 +55,6 @@ public:
 	auto phash() const {return m_phash;}
 
 private:
-	void generate_jpeg_rendition(BufferView jpeg_master, const JPEGRenditionSetting& cfg, std::string_view rendition, const fs::path& dir, std::error_code& err);
 	static TurboBuffer generate_rendition_from_jpeg(BufferView jpeg_master, Size2D dim, int quality, std::error_code& ec);
 
 private:

--- a/src/hrb/BlobFile.hh
+++ b/src/hrb/BlobFile.hh
@@ -48,7 +48,7 @@ public:
 		std::error_code& ec
 	);
 
-	void generate_jpeg_rendition(const JPEGRenditionSetting& cfg, std::string_view rendition);
+	void generate_jpeg_rendition(const JPEGRenditionSetting& cfg, std::string_view rendition, std::error_code& err);
 
 	BufferView buffer() const;
 	MMap& mmap() {return m_mmap;}

--- a/src/hrb/index/PHashDb.hh
+++ b/src/hrb/index/PHashDb.hh
@@ -18,8 +18,6 @@
 #include "net/Redis.hh"
 #include "util/Log.hh"
 
-#include <boost/range/adaptor/transformed.hpp>
-
 namespace hrb {
 namespace redis {
 class Connection;
@@ -50,7 +48,6 @@ public:
 					oids.remove_prefix(ObjectID{}.size());
 				}
 
-				using namespace boost::adaptors;
 				comp(std::move(result), err);
 			},
 			"HGET %b %d",

--- a/src/image/TurboBuffer.hh
+++ b/src/image/TurboBuffer.hh
@@ -13,7 +13,8 @@
 #pragma once
 
 #include "util/BufferView.hh"
-#include <cstddef>
+#include <boost/asio/buffer.hpp>
+#include <memory>
 
 namespace hrb {
 

--- a/src/util/Configuration.cc
+++ b/src/util/Configuration.cc
@@ -144,7 +144,7 @@ std::string Configuration::https_root() const
 		+ (listen_https().port() == 443 ? ""s : (":"s + std::to_string(listen_https().port())));
 }
 
-const RenditionSetting::Setting& RenditionSetting::find(std::string_view rend) const
+const JPEGRenditionSetting& RenditionSetting::find(std::string_view rend) const
 {
 	assert(m_renditions.find(std::string{m_default}) != m_renditions.end());
 
@@ -172,7 +172,7 @@ bool RenditionSetting::valid(std::string_view rend) const
 
 void RenditionSetting::add(std::string_view rend, Size2D dim, int quality)
 {
-	m_renditions.insert_or_assign(std::string{rend}, Setting{dim, quality});
+	m_renditions.insert_or_assign(std::string{rend}, JPEGRenditionSetting{dim, quality});
 }
 
 } // end of namespace

--- a/src/util/Configuration.hh
+++ b/src/util/Configuration.hh
@@ -26,6 +26,12 @@
 
 namespace hrb {
 
+struct JPEGRenditionSetting
+{
+	Size2D  dim;
+	int     quality;
+};
+
 class RenditionSetting
 {
 public:
@@ -34,6 +40,8 @@ public:
 	Size2D dimension(std::string_view rend = {}) const;
 	int quality(std::string_view rend = {}) const;
 
+	const JPEGRenditionSetting& find(std::string_view rend) const;
+
 	bool valid(std::string_view rend) const;
 	const std::string& default_rendition() const {return m_default;}
 	void default_rendition(std::string_view rend) {m_default = rend;}
@@ -41,16 +49,10 @@ public:
 	void add(std::string_view rend, Size2D dim, int quality=70);
 
 private:
-	struct Setting
-	{
-		Size2D  dim;
-		int     quality;
-	};
-
-	const Setting& find(std::string_view rend) const;
-
 	std::string m_default{"2048x2048"};
-	std::unordered_map<std::string, Setting> m_renditions{{m_default, Setting{{2048, 2048}, 70}}};
+	std::unordered_map<std::string, JPEGRenditionSetting> m_renditions{
+		{m_default, JPEGRenditionSetting{{2048, 2048}, 70}}
+	};
 };
 
 /// \brief  Parsing command line options and configuration file

--- a/src/util/MMap.cc
+++ b/src/util/MMap.cc
@@ -38,6 +38,7 @@ MMap::MMap(int fd)
 
 void MMap::cache() const
 {
+	// ignore error
 	::madvise(m_mmap, m_size, MADV_SEQUENTIAL);
 }
 

--- a/unittest/tests/hrb/BlobDatabase-UT.cc
+++ b/unittest/tests/hrb/BlobDatabase-UT.cc
@@ -54,7 +54,7 @@ TEST_CASE("Open temp file", "[normal]")
 	REQUIRE(tmpid != ObjectID{});
 	REQUIRE(tmpid == tmp.ID());
 
-	auto dest = subject.dest(subject.save(std::move(tmp), "testfile", sec).ID());
+	auto dest = subject.dest(subject.save(std::move(tmp), sec).ID());
 	INFO("save() error_code = " << sec << " " << sec.message());
 	REQUIRE(!sec);
 	REQUIRE(exists(dest/"master"));
@@ -83,6 +83,8 @@ TEST_CASE("Upload JPEG file to BlobDatabase", "[normal]")
 	tmp.write(black.data(), black.size(), bec);
 	REQUIRE(!bec);
 
-	auto id = subject.save(std::move(tmp), "black.jpg", ec).ID();
+	auto up_id = tmp.ID();
+	auto bb_id = subject.save(std::move(tmp), ec).ID();
 	REQUIRE(!ec);
+	REQUIRE(bb_id == up_id);
 }

--- a/unittest/tests/hrb/BlobObject-UT.cc
+++ b/unittest/tests/hrb/BlobObject-UT.cc
@@ -52,17 +52,11 @@ TEST_CASE("upload non-image BlobFile", "[normal]")
 	auto [tmp, src] = upload(__FILE__);
 
 	std::error_code ec;
-	auto subject = BlobFile::upload(std::move(tmp), "/tmp/BlobFile-UT", Magic{}, cfg, "unittest.cc", ec);
+	auto subject = BlobFile::upload(std::move(tmp), "/tmp/BlobFile-UT", Magic{}, ec);
 	REQUIRE(!ec);
 	REQUIRE(subject.ID() != ObjectID{});
-
-	auto meta = subject.entry();
-	REQUIRE(meta.mime() == "text/x-c");
-	REQUIRE(meta.filename() == "unittest.cc");
-
-//	subject.save("/tmp/BlobFile-UT", ec);
-	REQUIRE(!ec);
 	REQUIRE(fs::exists("/tmp/BlobFile-UT/master"));
+	REQUIRE(subject.mime() == "text/x-c");
 
 	auto out = MMap::open("/tmp/BlobFile-UT/master", ec);
 	REQUIRE(!ec);
@@ -95,15 +89,11 @@ TEST_CASE("upload small image BlobFile", "[normal]")
 	auto [tmp, src] = upload(image_path()/"black.jpg");
 
 	std::error_code ec;
-	auto subject = BlobFile::upload(std::move(tmp), "/tmp/BlobFile-UT", Magic{}, RenditionSetting{}, "black.jpeg", ec);
+	auto subject = BlobFile::upload(std::move(tmp), "/tmp/BlobFile-UT", Magic{}, ec);
 	REQUIRE(!ec);
 	REQUIRE(subject.ID() != ObjectID{});
+	REQUIRE(subject.mime() == "image/jpeg");
 
-	auto meta = subject.entry();
-	REQUIRE(meta.mime() == "image/jpeg");
-	REQUIRE(meta.filename() == "black.jpeg");
-
-//	subject.save("/tmp/BlobFile-UT", ec);
 	REQUIRE(!ec);
 	REQUIRE(fs::exists("/tmp/BlobFile-UT/master"));
 
@@ -120,28 +110,22 @@ TEST_CASE("upload big upright image BlobFile", "[normal]")
 
 	auto [tmp, src] = upload(image_path()/"up_f_upright.jpg");
 
-	RenditionSetting cfg;
-	cfg.add("128x128",   {128, 128});
-	cfg.add("thumbnail", {64, 64});
-	cfg.default_rendition("128x128");
-
 	std::error_code ec;
-	auto subject = BlobFile::upload(std::move(tmp), "/tmp/BlobFile-UT", Magic{}, cfg, "upright.jpeg", ec);
+	auto subject = BlobFile::upload(std::move(tmp), "/tmp/BlobFile-UT", Magic{}, ec);
 	REQUIRE(!ec);
 	REQUIRE(subject.ID() != ObjectID{});
-
-	auto meta = subject.entry();
-	REQUIRE(meta.mime() == "image/jpeg");
-	REQUIRE(meta.filename() == "upright.jpeg");
-
-//	subject.save("/tmp/BlobFile-UT", ec);
-	REQUIRE(!ec);
+	REQUIRE(subject.mime() == "image/jpeg");
 	REQUIRE(fs::exists("/tmp/BlobFile-UT/master"));
 
 	auto out = MMap::open("/tmp/BlobFile-UT/master", ec);
 	REQUIRE(!ec);
 	REQUIRE(out.size() == src.size());
 	REQUIRE(std::memcmp(out.data(), src.data(), out.size()) == 0);
+
+	RenditionSetting cfg;
+	cfg.add("128x128",   {128, 128});
+	cfg.add("thumbnail", {64, 64});
+	cfg.default_rendition("128x128");
 
 	auto rend128 = subject.rendition(cfg.default_rendition(), cfg, ec);
 	REQUIRE(!ec);

--- a/unittest/tests/hrb/BlobObject-UT.cc
+++ b/unittest/tests/hrb/BlobObject-UT.cc
@@ -52,7 +52,7 @@ TEST_CASE("upload non-image BlobFile", "[normal]")
 	auto [tmp, src] = upload(__FILE__);
 
 	std::error_code ec;
-	auto subject = BlobFile::upload(std::move(tmp), "/tmp/BlobFile-UT", Magic{}, ec);
+	BlobFile subject{std::move(tmp), "/tmp/BlobFile-UT", Magic{}, ec};
 	REQUIRE(!ec);
 	REQUIRE(subject.ID() != ObjectID{});
 	REQUIRE(fs::exists("/tmp/BlobFile-UT/master"));
@@ -89,7 +89,7 @@ TEST_CASE("upload small image BlobFile", "[normal]")
 	auto [tmp, src] = upload(image_path()/"black.jpg");
 
 	std::error_code ec;
-	auto subject = BlobFile::upload(std::move(tmp), "/tmp/BlobFile-UT", Magic{}, ec);
+	BlobFile subject{std::move(tmp), "/tmp/BlobFile-UT", Magic{}, ec};
 	REQUIRE(!ec);
 	REQUIRE(subject.ID() != ObjectID{});
 	REQUIRE(subject.mime() == "image/jpeg");
@@ -111,7 +111,7 @@ TEST_CASE("upload big upright image BlobFile", "[normal]")
 	auto [tmp, src] = upload(image_path()/"up_f_upright.jpg");
 
 	std::error_code ec;
-	auto subject = BlobFile::upload(std::move(tmp), "/tmp/BlobFile-UT", Magic{}, ec);
+	BlobFile subject{std::move(tmp), "/tmp/BlobFile-UT", Magic{}, ec};
 	REQUIRE(!ec);
 	REQUIRE(subject.ID() != ObjectID{});
 	REQUIRE(subject.mime() == "image/jpeg");

--- a/unittest/tests/hrb/BlobObject-UT.cc
+++ b/unittest/tests/hrb/BlobObject-UT.cc
@@ -52,7 +52,7 @@ TEST_CASE("upload non-image BlobFile", "[normal]")
 	auto [tmp, src] = upload(__FILE__);
 
 	std::error_code ec;
-	auto subject = BlobFile::upload(std::move(tmp), Magic{}, cfg, "unittest.cc", ec);
+	auto subject = BlobFile::upload(std::move(tmp), "/tmp/BlobFile-UT", Magic{}, cfg, "unittest.cc", ec);
 	REQUIRE(!ec);
 	REQUIRE(subject.ID() != ObjectID{});
 
@@ -60,7 +60,7 @@ TEST_CASE("upload non-image BlobFile", "[normal]")
 	REQUIRE(meta.mime() == "text/x-c");
 	REQUIRE(meta.filename() == "unittest.cc");
 
-	subject.save("/tmp/BlobFile-UT", ec);
+//	subject.save("/tmp/BlobFile-UT", ec);
 	REQUIRE(!ec);
 	REQUIRE(fs::exists("/tmp/BlobFile-UT/master"));
 
@@ -95,7 +95,7 @@ TEST_CASE("upload small image BlobFile", "[normal]")
 	auto [tmp, src] = upload(image_path()/"black.jpg");
 
 	std::error_code ec;
-	auto subject = BlobFile::upload(std::move(tmp), Magic{}, RenditionSetting{}, "black.jpeg", ec);
+	auto subject = BlobFile::upload(std::move(tmp), "/tmp/BlobFile-UT", Magic{}, RenditionSetting{}, "black.jpeg", ec);
 	REQUIRE(!ec);
 	REQUIRE(subject.ID() != ObjectID{});
 
@@ -103,7 +103,7 @@ TEST_CASE("upload small image BlobFile", "[normal]")
 	REQUIRE(meta.mime() == "image/jpeg");
 	REQUIRE(meta.filename() == "black.jpeg");
 
-	subject.save("/tmp/BlobFile-UT", ec);
+//	subject.save("/tmp/BlobFile-UT", ec);
 	REQUIRE(!ec);
 	REQUIRE(fs::exists("/tmp/BlobFile-UT/master"));
 
@@ -126,7 +126,7 @@ TEST_CASE("upload big upright image BlobFile", "[normal]")
 	cfg.default_rendition("128x128");
 
 	std::error_code ec;
-	auto subject = BlobFile::upload(std::move(tmp), Magic{}, cfg, "upright.jpeg", ec);
+	auto subject = BlobFile::upload(std::move(tmp), "/tmp/BlobFile-UT", Magic{}, cfg, "upright.jpeg", ec);
 	REQUIRE(!ec);
 	REQUIRE(subject.ID() != ObjectID{});
 
@@ -134,7 +134,7 @@ TEST_CASE("upload big upright image BlobFile", "[normal]")
 	REQUIRE(meta.mime() == "image/jpeg");
 	REQUIRE(meta.filename() == "upright.jpeg");
 
-	subject.save("/tmp/BlobFile-UT", ec);
+//	subject.save("/tmp/BlobFile-UT", ec);
 	REQUIRE(!ec);
 	REQUIRE(fs::exists("/tmp/BlobFile-UT/master"));
 

--- a/unittest/tests/hrb/BlobObject-UT.cc
+++ b/unittest/tests/hrb/BlobObject-UT.cc
@@ -72,18 +72,18 @@ TEST_CASE("upload non-image BlobFile", "[normal]")
 	SECTION("read back the original")
 	{
 		std::error_code read_ec;
-		BlobFile subject2{"/tmp/BlobFile-UT", subject.ID(), "master", cfg, read_ec};
+		BlobFile subject2{"/tmp/BlobFile-UT", subject.ID()};
 
+		REQUIRE(out.buffer() == subject2.rendition("master", cfg, read_ec).buffer());
 		REQUIRE(!read_ec);
-		REQUIRE(out.buffer() == subject2.buffer());
 	}
 	SECTION("read another rendition, but got the original")
 	{
 		std::error_code read_ec;
-		BlobFile subject2{"/tmp/BlobFile-UT", subject.ID(), "thumbnail", cfg, read_ec};
+		BlobFile subject2{"/tmp/BlobFile-UT", subject.ID()};
 
+		REQUIRE(out.buffer() == subject2.rendition("thumbnail", cfg, read_ec).buffer());
 		REQUIRE(!read_ec);
-		REQUIRE(out.buffer() == subject2.buffer());
 	}
 }
 
@@ -148,8 +148,8 @@ TEST_CASE("upload big upright image BlobFile", "[normal]")
 	REQUIRE(out128.size() < src.size());
 	REQUIRE(std::memcmp(out128.data(), src.data(), out128.size()) != 0);
 
-	BlobFile gen{"/tmp/BlobFile-UT", subject.ID(), "thumbnail", cfg, ec};
-	auto gen_mmap{std::move(gen.mmap())};
+	BlobFile gen{"/tmp/BlobFile-UT", subject.ID()};
+	auto gen_mmap = gen.rendition("thumbnail", cfg, ec);
 	REQUIRE(gen_mmap.size() > 0);
 
 	JPEG gen_jpeg{gen_mmap.buffer().data(), gen_mmap.size(), {64, 64}};

--- a/unittest/tests/hrb/BlobObject-UT.cc
+++ b/unittest/tests/hrb/BlobObject-UT.cc
@@ -143,6 +143,10 @@ TEST_CASE("upload big upright image BlobFile", "[normal]")
 	REQUIRE(out.size() == src.size());
 	REQUIRE(std::memcmp(out.data(), src.data(), out.size()) == 0);
 
+	auto rend128 = subject.rendition(cfg.default_rendition(), cfg, ec);
+	REQUIRE(!ec);
+	REQUIRE(rend128.buffer() != src.buffer());
+
 	auto out128 = MMap::open("/tmp/BlobFile-UT/128x128", ec);
 	REQUIRE(!ec);
 	REQUIRE(out128.size() < src.size());


### PR DESCRIPTION
Directly save the generated renditions into file instead of storing in memory.

Do not generate default rendition right after upload.